### PR TITLE
fix: handle strict property initialization for entities

### DIFF
--- a/src/person.entity.ts
+++ b/src/person.entity.ts
@@ -3,11 +3,11 @@ import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 @Entity()
 export class Person {
   @PrimaryGeneratedColumn()
-  id: number;
+  id!: number;
 
   @Column({ unique: true })
-  simpleName: string;
+  simpleName!: string;
 
   @Column()
-  fullName: string;
+  fullName!: string;
 }

--- a/src/queries/handlers/get-person.handler.ts
+++ b/src/queries/handlers/get-person.handler.ts
@@ -11,7 +11,7 @@ export class GetPersonHandler implements IQueryHandler<GetPersonQuery> {
     private readonly repo: Repository<Person>,
   ) {}
 
-  async execute(query: GetPersonQuery): Promise<Person | undefined> {
+  async execute(query: GetPersonQuery): Promise<Person | null> {
     return this.repo.findOne({ where: { simpleName: query.simpleName } });
   }
 }


### PR DESCRIPTION
## Summary
- add definite assignment assertions on Person entity fields
- align GetPersonHandler return type with TypeORM

## Testing
- `npm test` *(fails: No tests found)*
- `npm run start:dev`


------
https://chatgpt.com/codex/tasks/task_e_68a56d6b104883299dfff9b702683caf