### PR TITLE
Add scheduled workflow to propagate production tag

### DIFF
--- a/.github/workflows/scheduled-tag.yml
+++ b/.github/workflows/scheduled-tag.yml
@@ -1,0 +1,20 @@
+name: Propagate production tag
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  tag-other-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Propagate tag to another repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+        run: |
+          ./scripts/propagate-tag.sh

--- a/scripts/propagate-tag.sh
+++ b/scripts/propagate-tag.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -euo pipefail
+
+: "${TARGET_REPO:?TARGET_REPO env var required}"
+
+# Ensure we have all tags
+git fetch --tags
+
+# Find commit for PRODUCTION tag and its parent
+prod_commit=$(git rev-list -n 1 PRODUCTION)
+prev_commit=$(git rev-list -n 1 "${prod_commit}^")
+
+api="https://api.github.com/repos/${TARGET_REPO}/git/refs/tags/PRODUCTION_FROM_THIS_PROJECT"
+auth="Authorization: token ${GITHUB_TOKEN}"
+
+# If the tag exists, update it; otherwise create it
+if curl -fsS -H "$auth" "$api" >/dev/null 2>&1; then
+  curl -L -X PATCH -H "$auth" \
+    -H "Content-Type: application/json" \
+    -d "{\"sha\":\"${prev_commit}\",\"force\":true}" \
+    "$api"
+else
+  curl -L -X POST -H "$auth" \
+    -H "Content-Type: application/json" \
+    -d "{\"ref\":\"refs/tags/PRODUCTION_FROM_THIS_PROJECT\",\"sha\":\"${prev_commit}\"}" \
+    "https://api.github.com/repos/${TARGET_REPO}/git/refs"
+fi


### PR DESCRIPTION
## Summary
- schedule daily job to update `PRODUCTION_FROM_THIS_PROJECT` tag in another repository
- add helper script to push tag via GitHub API

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e39ca4848329882ebd54914b6ce6