### PR TITLE
feat: add admin panel and form configuration

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Panel</title>
+  <link rel="stylesheet" href="/style.css">
+  <style>
+    body { margin:0; font-family: Arial, sans-serif; }
+    #panel { display:none; height:100vh; }
+    .toolbar { width:200px; background:#2c3e50; color:white; padding:20px; box-sizing:border-box; }
+    .toolbar h2 { color:white; }
+    .content { flex:1; padding:20px; overflow:auto; }
+    #layout { display:flex; height:100%; }
+    table { width:100%; border-collapse: collapse; margin-top:10px; }
+    th, td { border:1px solid #ccc; padding:8px; text-align:left; }
+  </style>
+</head>
+<body>
+<div id="login">
+  <h2>Admin Login</h2>
+  <input id="username" placeholder="Username"/><br/>
+  <input id="password" type="password" placeholder="Password"/><br/>
+  <button onclick="login()">Login</button>
+  <p id="loginStatus"></p>
+</div>
+<div id="panel">
+  <div id="layout">
+    <div class="toolbar">
+      <h2>Admin</h2>
+      <div>Form Configs</div>
+    </div>
+    <div class="content">
+      <h2>Form Configurations</h2>
+      <form onsubmit="createConfig(event)">
+        <input id="cfgName" placeholder="Form name" required/>
+        <input id="cfgSeq" type="number" placeholder="Sequence" required/>
+        <textarea id="cfgFields" placeholder='[ {"id":"field1","label":"Name","type":"text"} ]' rows="3" style="width:100%;"></textarea>
+        <button type="submit">Save Config</button>
+      </form>
+      <table id="configTable"></table>
+      <h3>Preview</h3>
+      <div id="preview"></div>
+    </div>
+  </div>
+</div>
+<script>
+async function login() {
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  const res = await fetch('/api/admin/login', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({username, password})});
+  const data = await res.json();
+  if(data.success){
+    document.getElementById('login').style.display='none';
+    document.getElementById('panel').style.display='block';
+    loadConfigs();
+  } else {
+    document.getElementById('loginStatus').innerText='Invalid credentials';
+  }
+}
+async function loadConfigs(){
+  const res = await fetch('/api/form-configs');
+  const configs = await res.json();
+  const table = document.getElementById('configTable');
+  table.innerHTML='<tr><th>Name</th><th>Sequence</th><th>Export</th></tr>';
+  configs.forEach(cfg=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${cfg.name}</td><td>${cfg.sequence}</td><td><button onclick="exportCfg(${cfg.id})">Export</button></td>`;
+    tr.onclick=()=>showPreview(cfg);
+    table.appendChild(tr);
+  });
+}
+function showPreview(cfg){
+  const container=document.getElementById('preview');
+  container.innerHTML='';
+  const fields=JSON.parse(cfg.fields);
+  renderFields(container, fields);
+}
+function renderFields(container, fields){
+  const form=document.createElement('form');
+  fields.forEach(f=>{
+    const label=document.createElement('label');
+    label.textContent=f.label;
+    form.appendChild(label);
+    let input;
+    switch(f.type){
+      case 'textarea':
+        input=document.createElement('textarea'); break;
+      case 'date':
+        input=document.createElement('input'); input.type='date'; break;
+      case 'select':
+        input=document.createElement('select');
+        f.options.forEach(o=>{const opt=document.createElement('option'); opt.value=o; opt.textContent=o; input.appendChild(opt);});
+        break;
+      case 'radio':
+        input=document.createElement('div');
+        f.options.forEach(o=>{const r=document.createElement('input'); r.type='radio'; r.name=f.id; r.value=o; const l=document.createElement('label'); l.textContent=o; input.appendChild(r); input.appendChild(l);});
+        break;
+      default:
+        input=document.createElement('input'); input.type='text';
+    }
+    input.id=f.id;
+    form.appendChild(input);
+    form.appendChild(document.createElement('br'));
+  });
+  container.appendChild(form);
+}
+async function createConfig(e){
+  e.preventDefault();
+  const name=document.getElementById('cfgName').value;
+  const sequence=parseInt(document.getElementById('cfgSeq').value,10);
+  const fields=JSON.parse(document.getElementById('cfgFields').value || '[]');
+  await fetch('/api/form-configs',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,sequence,fields})});
+  loadConfigs();
+  e.target.reset();
+}
+function exportCfg(id){
+  window.location='/api/form-configs/'+id+'/export';
+}
+</script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -2,24 +2,63 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Hello</title>
+  <title>Dynamic Forms</title>
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-  <div class="container">
-    <h1>Hello Lookup</h1>
-    <input id="who" placeholder="Enter simple name" />
-    <button onclick="sayHello()">Say Hello</button>
-    <p id="result"></p>
-    <a href="add.html">Add Name</a>
-  </div>
+  <div class="container" id="formsContainer"></div>
   <script>
-    async function sayHello() {
-      const who = document.getElementById('who').value;
-      const res = await fetch('/hello?who=' + encodeURIComponent(who));
-      const data = await res.json();
-      document.getElementById('result').innerText = data.message;
+    async function loadForms(){
+      const res = await fetch('/api/form-configs');
+      const configs = await res.json();
+      const container = document.getElementById('formsContainer');
+      container.innerHTML='';
+      configs.forEach(cfg=>{
+        const form=document.createElement('form');
+        form.innerHTML='<h2>'+cfg.name+'</h2>';
+        const fields=JSON.parse(cfg.fields);
+        fields.forEach(f=>{
+          const label=document.createElement('label'); label.textContent=f.label; form.appendChild(label);
+          let input;
+          switch(f.type){
+            case 'textarea': input=document.createElement('textarea'); break;
+            case 'date': input=document.createElement('input'); input.type='date'; break;
+            case 'select':
+              input=document.createElement('select');
+              (f.options||[]).forEach(o=>{const opt=document.createElement('option'); opt.value=o; opt.textContent=o; input.appendChild(opt);});
+              break;
+            case 'radio':
+              input=document.createElement('div');
+              (f.options||[]).forEach(o=>{const r=document.createElement('input'); r.type='radio'; r.name=f.id; r.value=o; const l=document.createElement('label'); l.textContent=o; input.appendChild(r); input.appendChild(l);});
+              break;
+            default:
+              input=document.createElement('input'); input.type='text';
+          }
+          input.id=f.id;
+          form.appendChild(input);
+          form.appendChild(document.createElement('br'));
+        });
+        const btn=document.createElement('button'); btn.type='submit'; btn.textContent='Submit';
+        form.appendChild(btn);
+        form.addEventListener('submit', async e=>{
+          e.preventDefault();
+          const data={};
+          fields.forEach(f=>{
+            if(f.type==='radio'){
+              const checked=form.querySelector('input[name="'+f.id+'"]:checked');
+              data[f.id]=checked?checked.value:null;
+            } else {
+              data[f.id]=form.querySelector('#'+f.id).value;
+            }
+          });
+          await fetch('/api/form-configs/'+cfg.id+'/records',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});
+          alert('Saved');
+          form.reset();
+        });
+        container.appendChild(form);
+      });
     }
+    loadForms();
   </script>
 </body>
 </html>

--- a/src/admin.controller.ts
+++ b/src/admin.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Post, Body, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Admin } from './admin.entity';
+
+@Controller('api/admin')
+export class AdminController implements OnModuleInit {
+  constructor(@InjectRepository(Admin) private repo: Repository<Admin>) {}
+
+  async onModuleInit() {
+    const count = await this.repo.count();
+    if (count === 0) {
+      await this.repo.save({ username: 'admin', password: 'password' });
+    }
+  }
+
+  @Post('login')
+  async login(@Body() body: { username: string; password: string }) {
+    const admin = await this.repo.findOne({ where: { username: body.username } });
+    if (admin && admin.password === body.password) {
+      return { success: true };
+    }
+    return { success: false };
+  }
+}

--- a/src/admin.entity.ts
+++ b/src/admin.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Admin {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ unique: true })
+  username!: string;
+
+  @Column()
+  password!: string;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,11 @@ import { Person } from './person.entity';
 import { AppController } from './app.controller';
 import { CreatePersonHandler } from './commands/handlers/create-person.handler';
 import { GetPersonHandler } from './queries/handlers/get-person.handler';
+import { Admin } from './admin.entity';
+import { FormConfig } from './form-config.entity';
+import { FormRecord } from './form-record.entity';
+import { AdminController } from './admin.controller';
+import { FormConfigController } from './form-config.controller';
 
 @Module({
   imports: [
@@ -12,12 +17,12 @@ import { GetPersonHandler } from './queries/handlers/get-person.handler';
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'data/database.sqlite',
-      entities: [Person],
+      entities: [Person, Admin, FormConfig, FormRecord],
       synchronize: true,
     }),
-    TypeOrmModule.forFeature([Person]),
+    TypeOrmModule.forFeature([Person, Admin, FormConfig, FormRecord]),
   ],
-  controllers: [AppController],
+  controllers: [AppController, AdminController, FormConfigController],
   providers: [CreatePersonHandler, GetPersonHandler],
 })
 export class AppModule {}

--- a/src/form-config.controller.ts
+++ b/src/form-config.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Post, Param, Body } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FormConfig } from './form-config.entity';
+import { FormRecord } from './form-record.entity';
+
+@Controller('api')
+export class FormConfigController {
+  constructor(
+    @InjectRepository(FormConfig)
+    private readonly configRepo: Repository<FormConfig>,
+    @InjectRepository(FormRecord)
+    private readonly recordRepo: Repository<FormRecord>,
+  ) {}
+
+  @Get('form-configs')
+  getConfigs() {
+    return this.configRepo.find({ order: { sequence: 'ASC' } });
+  }
+
+  @Post('form-configs')
+  createConfig(
+    @Body()
+    body: { name: string; sequence: number; fields: any },
+  ) {
+    const config = this.configRepo.create({
+      name: body.name,
+      sequence: body.sequence,
+      fields: JSON.stringify(body.fields),
+    });
+    return this.configRepo.save(config);
+  }
+
+  @Get('form-configs/:id/export')
+  async exportConfig(@Param('id') id: number) {
+    const config = await this.configRepo.findOneBy({ id: +id });
+    return config;
+  }
+
+  @Post('form-configs/:id/records')
+  async saveRecord(@Param('id') id: number, @Body() data: any) {
+    const config = await this.configRepo.findOneBy({ id: +id });
+    if (!config) {
+      return { success: false };
+    }
+    const record = this.recordRepo.create({
+      form: config,
+      data: JSON.stringify(data),
+    });
+    await this.recordRepo.save(record);
+    return { success: true };
+  }
+}

--- a/src/form-config.entity.ts
+++ b/src/form-config.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class FormConfig {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  name!: string;
+
+  @Column({ default: 0 })
+  sequence!: number;
+
+  @Column('text')
+  fields!: string; // JSON string defining fields
+}

--- a/src/form-record.entity.ts
+++ b/src/form-record.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { FormConfig } from './form-config.entity';
+
+@Entity()
+export class FormRecord {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => FormConfig, { onDelete: 'CASCADE' })
+  form!: FormConfig;
+
+  @Column('text')
+  data!: string; // JSON of submitted values
+}


### PR DESCRIPTION
## Summary
- add admin authentication controller with default admin user
- implement form configuration and record endpoints
- add simple admin panel UI and dynamic form rendering on home page

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a5e9aabef883298f4aa99e370c1d42