### PR TITLE
chore: push PRODUCTION_FROM_THIS_PROJECT tag using git

### DIFF
--- a/.github/workflows/scheduled-tag.yml
+++ b/.github/workflows/scheduled-tag.yml
@@ -1,0 +1,20 @@
+name: Propagate production tag
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  tag-other-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Propagate tag to another repository
+        env:
+          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          TARGET_TOKEN: ${{ secrets.TARGET_TOKEN }}
+        run: |
+          ./scripts/propagate-tag.sh

--- a/scripts/propagate-tag.sh
+++ b/scripts/propagate-tag.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -euo pipefail
+
+: "${TARGET_REPO:?TARGET_REPO env var required}"
+: "${TARGET_TOKEN:?TARGET_TOKEN env var required}"
+
+# Ensure we have all tags
+git fetch --tags
+
+# Find commit for PRODUCTION tag and its parent
+prod_commit=$(git rev-list -n 1 PRODUCTION)
+prev_commit=$(git rev-list -n 1 "${prod_commit}^")
+
+# Determine server URL (defaults to github.com)
+server="${GITHUB_SERVER_URL:-https://github.com}"
+remote="https://${TARGET_TOKEN}@${server#https://}/${TARGET_REPO}.git"
+
+# Force-push tag to target repository
+git push "$remote" "${prev_commit}:refs/tags/PRODUCTION_FROM_THIS_PROJECT" --force


### PR DESCRIPTION
## Summary
- replace GitHub API calls with `git push` in propagate-tag script
- provide `TARGET_TOKEN` secret in scheduled workflow for pushing tags

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e39ca4848329882ebd54914b6ce6