### PR TITLE
Revise form configuration schema and UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,12 @@ services:
     restart: always
     ports:
       - "27017:27017"
+  mongo-express:
+    image: mongo-express:latest
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      ME_CONFIG_MONGODB_SERVER: mongo
+    depends_on:
+      - mongo

--- a/public/admin.html
+++ b/public/admin.html
@@ -27,9 +27,17 @@
       const [username, setUsername] = useState('');
       const [password, setPassword] = useState('');
 
-      const [name, setName] = useState('');
-      const [sequence, setSequence] = useState('');
+      const [formCd, setFormCd] = useState('');
+      const [formVersion, setFormVersion] = useState('');
+      const [displaySeq, setDisplaySeq] = useState('');
       const [fields, setFields] = useState([]);
+
+      useEffect(()=>{
+        if(localStorage.getItem('loggedIn')==='true'){
+          setLoggedIn(true);
+          loadConfigs();
+        }
+      },[]);
 
       const login = async () => {
         const res = await fetch('/api/admin/login', {
@@ -40,6 +48,7 @@
         const data = await res.json();
         if(data.success){
           setLoggedIn(true);
+          localStorage.setItem('loggedIn','true');
           loadConfigs();
         } else {
           alert('Invalid credentials');
@@ -52,7 +61,7 @@
       };
 
       const addField = () => {
-        setFields([...fields, { id:'', label:'', type:'text', options:'' }]);
+        setFields([...fields, { fieldId:'', fieldName:'', label:'', type:'text', option:[] }]);
       };
 
       const updateField = (idx, key, value) => {
@@ -69,25 +78,32 @@
 
       const saveConfig = async () => {
         const payload = {
-          name,
-          sequence: Number(sequence),
+          formCd,
+          formVersion,
+          displaySeq: Number(displaySeq),
           fields: fields.map(f=>({
-            id: f.id,
+            fieldId: f.fieldId,
+            fieldName: f.fieldName,
             label: f.label,
             type: f.type,
-            options: f.options ? f.options.split(',').map(o=>o.trim()).filter(o=>o) : []
+            option: f.option
           }))
         };
         await fetch('/api/form-configs',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
-        setName(''); setSequence(''); setFields([]);
+        setFormCd(''); setFormVersion(''); setDisplaySeq(''); setFields([]);
         loadConfigs();
+      };
+
+      const logout = () => {
+        localStorage.removeItem('loggedIn');
+        setLoggedIn(false);
       };
 
       if(!loggedIn){
         return (
-          <Box sx={{p:2, maxWidth:400, m:'auto'}}>
-            <TextField fullWidth label="Username" margin="normal" value={username} onChange={e=>setUsername(e.target.value)} />
-            <TextField fullWidth type="password" label="Password" margin="normal" value={password} onChange={e=>setPassword(e.target.value)} />
+          <Box sx={{p:2, maxWidth:400, m:'auto'}} component="form" autoComplete="off">
+            <TextField fullWidth label="Username" margin="normal" value={username} onChange={e=>setUsername(e.target.value)} autoComplete="off" InputLabelProps={{shrink:true}} />
+            <TextField fullWidth type="password" label="Password" margin="normal" value={password} onChange={e=>setPassword(e.target.value)} autoComplete="new-password" InputLabelProps={{shrink:true}} />
             <Button variant="contained" onClick={login}>Login</Button>
           </Box>
         );
@@ -97,28 +113,42 @@
         <Box sx={{display:'flex', height:'100vh'}}>
           <Box sx={{width:250, bgcolor:'#2c3e50', color:'white', p:2}}>
             <h2>Admin</h2>
-            <Button variant="contained" color="secondary" onClick={addField}>Add Field</Button>
+            <Button variant="contained" color="secondary" onClick={logout}>Logout</Button>
           </Box>
           <Box sx={{flex:1, p:2, overflow:'auto'}}>
             <h2>Form Configurations</h2>
-            <Box sx={{mb:2}}>
-              <TextField label="Form name" value={name} onChange={e=>setName(e.target.value)} sx={{mr:2}} />
-              <TextField type="number" label="Sequence" value={sequence} onChange={e=>setSequence(e.target.value)} />
+            <Box sx={{mb:2, display:'flex', gap:2, flexWrap:'wrap'}}>
+              <TextField label="Form Code" value={formCd} onChange={e=>setFormCd(e.target.value)} />
+              <TextField label="Form Version" value={formVersion} onChange={e=>setFormVersion(e.target.value)} />
+              <TextField type="number" label="Display Seq" value={displaySeq} onChange={e=>setDisplaySeq(e.target.value)} />
             </Box>
             {fields.map((f, idx)=>(
               <FieldEditor key={idx} field={f} onChange={(key,val)=>updateField(idx,key,val)} onRemove={()=>removeField(idx)} />
             ))}
+            <Button variant="outlined" onClick={addField} sx={{mt:1}}>Add Field</Button>
+            {fields.length>0 && (
+              <Table sx={{mt:2}}>
+                <TableHead>
+                  <TableRow><TableCell>Field Name</TableCell><TableCell>Type</TableCell></TableRow>
+                </TableHead>
+                <TableBody>
+                  {fields.map((f,idx)=>(
+                    <TableRow key={idx}><TableCell>{f.fieldName}</TableCell><TableCell>{f.type}</TableCell></TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
             <Button variant="contained" onClick={saveConfig} sx={{mt:2}}>Save Config</Button>
             <Table sx={{mt:4}}>
               <TableHead>
-                <TableRow><TableCell>Name</TableCell><TableCell>Sequence</TableCell><TableCell>Export</TableCell></TableRow>
+                <TableRow><TableCell>Form Code</TableCell><TableCell>Display Seq</TableCell><TableCell>Export</TableCell></TableRow>
               </TableHead>
               <TableBody>
                 {configs.map(cfg=>(
-                  <TableRow key={cfg.id}>
-                    <TableCell>{cfg.name}</TableCell>
-                    <TableCell>{cfg.sequence}</TableCell>
-                    <TableCell><Button onClick={()=>window.location=`/api/form-configs/${cfg.id}/export`}>Export</Button></TableCell>
+                  <TableRow key={cfg._id}>
+                    <TableCell>{cfg.formCd}</TableCell>
+                    <TableCell>{cfg.displaySeq}</TableCell>
+                    <TableCell><Button onClick={()=>window.location=`/api/form-configs/${cfg._id}/export`}>Export</Button></TableCell>
                   </TableRow>
                 ))}
               </TableBody>
@@ -129,9 +159,21 @@
     }
 
     function FieldEditor({field, onChange, onRemove}){
+      const addOption = () => onChange('option', [...(field.option||[]), '']);
+      const updateOption = (idx, val) => {
+        const copy = field.option.slice();
+        copy[idx] = val;
+        onChange('option', copy);
+      };
+      const removeOption = (idx) => {
+        const copy = field.option.slice();
+        copy.splice(idx,1);
+        onChange('option', copy);
+      };
       return (
-        <Box sx={{display:'flex', gap:1, mb:1, p:1, border:'1px solid #ccc', borderRadius:1}}>
-          <TextField label="Id" value={field.id} onChange={e=>onChange('id', e.target.value)} />
+        <Box sx={{display:'flex', gap:1, mb:1, p:1, border:'1px solid #ccc', borderRadius:1, flexWrap:'wrap'}}>
+          <TextField label="Field Id" value={field.fieldId} onChange={e=>onChange('fieldId', e.target.value)} />
+          <TextField label="Field Name" value={field.fieldName} onChange={e=>onChange('fieldName', e.target.value)} />
           <TextField label="Label" value={field.label} onChange={e=>onChange('label', e.target.value)} />
           <Select value={field.type} onChange={e=>onChange('type', e.target.value)}>
             <MenuItem value="text">Text</MenuItem>
@@ -141,7 +183,15 @@
             <MenuItem value="radio">Radio</MenuItem>
           </Select>
           {(field.type === 'select' || field.type === 'radio') && (
-            <TextField label="Options (comma separated)" value={field.options} onChange={e=>onChange('options', e.target.value)} />
+            <Box sx={{display:'flex', flexDirection:'column'}}>
+              {(field.option||[]).map((opt,idx)=>(
+                <Box key={idx} sx={{display:'flex', alignItems:'center'}}>
+                  <TextField label={`Option ${idx+1}`} value={opt} onChange={e=>updateOption(idx,e.target.value)} />
+                  <IconButton onClick={()=>removeOption(idx)}>x</IconButton>
+                </Box>
+              ))}
+              <Button onClick={addOption}>Add Option</Button>
+            </Box>
           )}
           <Button color="error" onClick={onRemove}>Remove</Button>
         </Box>

--- a/public/index.html
+++ b/public/index.html
@@ -18,57 +18,86 @@
   <div id="root"></div>
   <script type="text/babel">
     const { useState, useEffect } = React;
-    const { Tabs, Tab, Box, TextField, Button, MenuItem, RadioGroup, FormControlLabel, Radio, FormLabel, Select, InputLabel } = MaterialUI;
+    const { Tabs, Tab, Box, TextField, Button, MenuItem, RadioGroup, FormControlLabel, Radio, FormLabel, Select, InputLabel, Table, TableHead, TableRow, TableCell, TableBody, Snackbar } = MaterialUI;
 
     function App(){
       const [configs, setConfigs] = useState([]);
       const [current, setCurrent] = useState(0);
+      const [formValues, setFormValues] = useState({});
+      const [records, setRecords] = useState([]);
+      const [toast, setToast] = useState(false);
+
+      const loadConfigs = async () => {
+        const data = await fetch('/api/form-configs').then(r=>r.json());
+        setConfigs(data);
+        const initial = {};
+        data.forEach(cfg=>{ initial[cfg._id] = {}; });
+        setFormValues(initial);
+      };
+
+      const loadRecords = async () => {
+        const recs = await fetch('/api/form-records').then(r=>r.json());
+        setRecords(recs);
+      };
 
       useEffect(() => {
-        fetch('/api/form-configs').then(r=>r.json()).then(data=>setConfigs(data));
+        loadConfigs();
+        loadRecords();
       }, []);
 
-      const handleSubmit = async (cfg, values) => {
-        await fetch(`/api/form-configs/${cfg.id}/records`, {
+      const updateValue = (formId, fieldId, value) => {
+        setFormValues(prev => ({ ...prev, [formId]: { ...(prev[formId]||{}), [fieldId]: value } }));
+      };
+
+      const handleSubmit = async (cfg) => {
+        await fetch(`/api/form-configs/${cfg._id}/records`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(values)
+          body: JSON.stringify(formValues[cfg._id] || {})
         });
-        alert('Saved');
+        setFormValues(prev => ({ ...prev, [cfg._id]: {} }));
+        await loadRecords();
+        setToast(true);
+      };
+
+      const handleRecordSelect = (rec) => {
+        const index = configs.findIndex(c=>c._id===rec.formId);
+        if(index>=0){
+          setCurrent(index);
+          setFormValues(prev=>({ ...prev, [rec.formId]: rec.data }));
+          window.scrollTo({top:0, behavior:'smooth'});
+        }
       };
 
       return (
         <Box sx={{p:2}}>
           <Tabs value={current} onChange={(e,v)=>setCurrent(v)}>
             {configs.map((cfg, idx)=>(
-              <Tab label={cfg.name} key={cfg.id} />
+              <Tab label={cfg.formCd} key={cfg._id} />
             ))}
           </Tabs>
           {configs[current] && (
-            <FormRenderer config={configs[current]} onSubmit={handleSubmit} />
+            <FormRenderer config={configs[current]} values={formValues[configs[current]._id] || {}} onChangeField={(id,val)=>updateValue(configs[current]._id,id,val)} onSubmit={()=>handleSubmit(configs[current])} />
           )}
+          <RecordList records={records} configs={configs} onSelect={handleRecordSelect} />
+          <Snackbar open={toast} autoHideDuration={2000} message="Saved" onClose={()=>setToast(false)} />
         </Box>
       );
     }
 
-    function FormRenderer({config, onSubmit}){
-      const [values, setValues] = useState({});
+    function FormRenderer({config, values, onChangeField, onSubmit}){
       const fields = config.fields || [];
-
-      const handleChange = (id, value) => {
-        setValues(prev=>({ ...prev, [id]: value }));
-      };
 
       const submit = (e) => {
         e.preventDefault();
-        onSubmit(config, values);
+        onSubmit();
       };
 
       return (
-        <Box component="form" onSubmit={submit} sx={{mt:2, p:2, border:'1px solid #ccc', borderRadius:1}}>
+        <Box component="form" onSubmit={submit} sx={{mt:2, p:2, border:'1px solid #ccc', borderRadius:1, maxWidth:500, mx:'auto'}}>
           {fields.map(f=>(
-            <Box key={f.id} sx={{mb:2}}>
-              {renderField(f, values[f.id] || '', (val)=>handleChange(f.id, val))}
+            <Box key={f.fieldId} sx={{mb:2}}>
+              {renderField(f, values[f.fieldId] || '', (val)=>onChangeField(f.fieldId, val))}
             </Box>
           ))}
           <Button type="submit" variant="contained">Submit</Button>
@@ -85,7 +114,7 @@
         case 'select':
           return (
             <TextField select fullWidth label={f.label} value={value} onChange={e=>onChange(e.target.value)}>
-              {(f.options||[]).map(o=>(
+              {(f.option||[]).map(o=>(
                 <MenuItem key={o} value={o}>{o}</MenuItem>
               ))}
             </TextField>
@@ -95,7 +124,7 @@
             <Box>
               <FormLabel>{f.label}</FormLabel>
               <RadioGroup value={value} onChange={e=>onChange(e.target.value)}>
-                {(f.options||[]).map(o=>(
+                {(f.option||[]).map(o=>(
                   <FormControlLabel key={o} value={o} control={<Radio />} label={o} />
                 ))}
               </RadioGroup>
@@ -104,6 +133,30 @@
         default:
           return <TextField fullWidth label={f.label} value={value} onChange={e=>onChange(e.target.value)} />;
       }
+    }
+
+    function RecordList({records, configs, onSelect}){
+      return (
+        <Box sx={{mt:4}}>
+          <h3>Records</h3>
+          <Table>
+            <TableHead>
+              <TableRow><TableCell>Form</TableCell><TableCell>Action</TableCell></TableRow>
+            </TableHead>
+            <TableBody>
+              {records.map(rec=>{
+                const cfg = configs.find(c=>c._id===rec.formId);
+                return (
+                  <TableRow key={rec.id}>
+                    <TableCell>{cfg ? cfg.formCd : rec.formId}</TableCell>
+                    <TableCell><Button onClick={()=>onSelect(rec)}>Select</Button></TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </Box>
+      );
     }
 
     ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/public/style.css
+++ b/public/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: 'Roboto', sans-serif;
-  background: linear-gradient(135deg, #667eea, #764ba2);
+  background: linear-gradient(135deg, #1877f2, #3b5998);
   color: #fff;
   margin: 0;
 }

--- a/src/form-config.controller.ts
+++ b/src/form-config.controller.ts
@@ -16,17 +16,29 @@ export class FormConfigController {
 
   @Get('form-configs')
   getConfigs() {
-    return this.configRepo.find({ order: { sequence: 1 as any } });
+    return this.configRepo.find({ order: { displaySeq: 1 as any } });
   }
 
   @Post('form-configs')
   createConfig(
     @Body()
-    body: { name: string; sequence: number; fields: any[] },
+    body: {
+      formCd: string;
+      formVersion: string;
+      displaySeq: number;
+      fields: {
+        fieldId: string;
+        fieldName: string;
+        label: string;
+        type: string;
+        option: string[];
+      }[];
+    },
   ) {
     const config = this.configRepo.create({
-      name: body.name,
-      sequence: body.sequence,
+      formCd: body.formCd,
+      formVersion: body.formVersion,
+      displaySeq: body.displaySeq,
       fields: body.fields,
     });
     return this.configRepo.save(config);
@@ -45,10 +57,21 @@ export class FormConfigController {
       return { success: false };
     }
     const record = this.recordRepo.create({
-      formId: config.id,
+      formId: config._id,
       data,
     });
     await this.recordRepo.save(record);
     return { success: true };
+  }
+
+  @Get('form-configs/:id/records')
+  async listRecords(@Param('id') id: string) {
+    const formId = new ObjectId(id);
+    return this.recordRepo.find({ where: { formId } });
+  }
+
+  @Get('form-records')
+  async listAllRecords() {
+    return this.recordRepo.find();
   }
 }

--- a/src/form-config.entity.ts
+++ b/src/form-config.entity.ts
@@ -3,14 +3,23 @@ import { Entity, ObjectIdColumn, ObjectId, Column } from 'typeorm';
 @Entity()
 export class FormConfig {
   @ObjectIdColumn()
-  id!: ObjectId;
+  _id!: ObjectId;
 
   @Column()
-  name!: string;
+  formCd!: string;
+
+  @Column()
+  formVersion!: string;
 
   @Column({ default: 0 })
-  sequence!: number;
+  displaySeq!: number;
 
   @Column()
-  fields!: any[]; // Array defining fields
+  fields!: {
+    fieldId: string;
+    fieldName: string;
+    label: string;
+    type: string;
+    option: string[];
+  }[]; // Array defining fields
 }


### PR DESCRIPTION
## Summary
- adopt new form configuration structure with formCd, formVersion, displaySeq and detailed field definitions
- enhance admin panel with persistent login, dynamic field options, field summary table, and Facebook-styled theme
- improve public forms with record list, toast notifications and form width, plus add Mongo Express service

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a890b5b9c48329956c46dc31785104